### PR TITLE
Temporarily disable fgdc2iso

### DIFF
--- a/vars.development.yml
+++ b/vars.development.yml
@@ -1,7 +1,7 @@
 app_name: fgdc2iso
 
 # Number of application instances to run in cloud.gov
-instances: 1
+instances: 0
 
 routes:
   - route: fgdc2iso-dev.apps.internal

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -1,7 +1,7 @@
 app_name: fgdc2iso
 
 # Number of application instances to run in cloud.gov
-instances: 1
+instances: 0
 
 routes:
   - route: fgdc2iso-production.apps.internal

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -1,7 +1,7 @@
 app_name: fgdc2iso
 
 # Number of application instances to run in cloud.gov
-instances: 1
+instances: 0
 
 routes:
   - route: fgdc2iso-stage.apps.internal


### PR DESCRIPTION
Currently we're not running harvesters and looking to save some memory quota. Also, we're planning to [replace the fgdc2iso service][1].

[1]: https://github.com/GSA/datagov-deploy/issues/2917