### PR TITLE
Remove deployment to cloud.gov

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -35,75 +35,7 @@ jobs:
         name: war-file
         path: build/fgdc2iso.war
         if-no-files-found: error
-  
-  deploy-development:
-    if: github.ref == 'refs/heads/develop'
-    name: deploy (development)
-    environment: development
-    runs-on: ubuntu-latest
-    needs: test
 
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: war-file
-          path: build
-      - name: deploy
-        uses: usds/cloud-gov-cli@master
-        with:
-          command: push fgdc2iso --vars-file vars.development.yml -p build/fgdc2iso.war --strategy rolling
-          org: gsa-datagov
-          space: development
-          user: ${{secrets.CF_SERVICE_USER}}
-          password: ${{secrets.CF_SERVICE_AUTH}}
-  
-  deploy-staging:
-    if: github.ref == 'refs/heads/main'
-    name: deploy (staging)
-    environment: staging
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: war-file
-          path: build
-      - name: deploy
-        uses: usds/cloud-gov-cli@master
-        with:
-          command: push fgdc2iso --vars-file vars.staging.yml -p build/fgdc2iso.war --strategy rolling
-          org: gsa-datagov
-          space: staging
-          user: ${{secrets.CF_SERVICE_USER}}
-          password: ${{secrets.CF_SERVICE_AUTH}}
-  deploy-production:
-    if: github.ref == 'refs/heads/main'
-    name: deploy (production)
-    environment: production
-    runs-on: ubuntu-latest
-    needs: deploy-staging
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: war-file
-          path: build
-      - name: deploy
-        uses: usds/cloud-gov-cli@master
-        with:
-          command: push fgdc2iso --vars-file vars.production.yml -p build/fgdc2iso.war --strategy rolling
-          org: gsa-datagov
-          space: prod
-          user: ${{secrets.CF_SERVICE_USER}}
-          password: ${{secrets.CF_SERVICE_AUTH}}
-  
   publish-war:
     if: github.ref == 'refs/heads/main'
     name: 'Publish War File'


### PR DESCRIPTION
Missed that this was already setup to auto-deploy to cloud.gov in #16. Removes the deployment code.